### PR TITLE
Improve readability of example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ int main(){
 
     // Eval the sum of the list
     PyObject* result = vm->eval("sum(a)");
-    std::cout << py_cast<int>(vm, result);   // 6
+    std::cout << "Sum of the list: "<< py_cast<int>(vm, result) << std::endl;   // 6
 
     // Bindings
     vm->bind(vm->_main, "add(a: int, b: int)",
@@ -104,7 +104,7 @@ int main(){
     // Call the function
     PyObject* f_add = vm->_main->attr("add");
     result = vm->call(f_add, py_var(vm, 3), py_var(vm, 7));
-    std::cout << py_cast<int>(vm, result);   // 10
+    std::cout << "Sum of 2 variables: "<< py_cast<int>(vm, result) << std::endl;   // 10
 
     // Dispose the virtual machine
     delete vm;

--- a/README_zh.md
+++ b/README_zh.md
@@ -51,7 +51,7 @@ int main(){
 
     // 计算列表元素之和
     PyObject* result = vm->eval("sum(a)");
-    std::cout << py_cast<int>(vm, result);   // 6
+    std::cout << "Sum of the list: "<< py_cast<int>(vm, result) << std::endl;   // 6
 
     // 绑定一个函数
     vm->bind(vm->_main, "add(a: int, b: int)",
@@ -64,7 +64,7 @@ int main(){
     // 调用函数
     PyObject* f_add = vm->_main->attr("add");
     result = vm->call(f_add, py_var(vm, 3), py_var(vm, 7));
-    std::cout << py_cast<int>(vm, result);   // 10
+    std::cout << "Sum of 2 variables: "<< py_cast<int>(vm, result) << std::endl;   // 10
 
     // 释放虚拟机
     delete vm;

--- a/docs/quick-start/installation.md
+++ b/docs/quick-start/installation.md
@@ -102,7 +102,7 @@ int main(){
 
     // Eval the sum of the list
     PyObject* result = vm->eval("sum(a)");
-    std::cout << py_cast<int>(vm, result);   // 6
+    std::cout << "Sum of the list: "<< py_cast<int>(vm, result) << std::endl;   // 6
 
     // Bindings
     vm->bind(vm->_main, "add(a: int, b: int)",
@@ -115,7 +115,7 @@ int main(){
     // Call the function
     PyObject* f_add = vm->_main->attr("add");
     result = vm->call(f_add, py_var(vm, 3), py_var(vm, 7));
-    std::cout << py_cast<int>(vm, result);   // 10
+    std::cout << "Sum of 2 variables: "<< py_cast<int>(vm, result) << std::endl;   // 10
 
     // Dispose the virtual machine
     delete vm;


### PR DESCRIPTION
A minor change to the example in the README files. I believe it shouldn't have any blockers. Thanks !

Example (Main) - 
```
C:\Users\kunni\pocketpy>try.exe
Hello world!
610
```

Example (Branch) - 
```
C:\Users\kunni\pocketpy>try.exe
Hello world!
Sum of the list: 6
Sum of 2 variables: 10
```