### PR TITLE
Add coverage for subset operators.

### DIFF
--- a/python/_set.py
+++ b/python/_set.py
@@ -59,6 +59,26 @@ class set:
                 ret.add(elem) 
         return ret
 
+    def __lt__(self, other):
+        if len(self) >= len(other):
+            return False
+        for elem in self:
+            if elem not in other:
+                return False
+        return True
+
+    def __le__(self, other):
+        for elem in self:
+            if elem not in other:
+                return False
+        return True
+
+    def __gt__(self, other):
+        return other < self
+
+    def __ge__(self, other):
+        return other <= self
+
     def union(self, other):
         return self | other
 
@@ -78,10 +98,10 @@ class set:
         return self.__and__(other).__len__() == 0
     
     def issubset(self, other):
-        return self.__sub__(other).__len__() == 0
+        return self <= other
     
     def issuperset(self, other):
-        return other.__sub__(self).__len__() == 0
+        return self >= other
 
     def __contains__(self, elem):
         return elem in self._a


### PR DESCRIPTION
On Main - 
```
>>> set1 = {1, 2, 3, 4, 5}
>>> set2 = {1, 2, 3}
>>> set2 < set1
Traceback (most recent call last):
  File "<stdin>", line 1
    set2 < set1
TypeError: unsupported operand type(s) for <: 'set' and 'set'
>>> set3 = {2, 3, 4, 5}
>>> set1 > set3
Traceback (most recent call last):
  File "<stdin>", line 1
    set1 > set3
TypeError: unsupported operand type(s) for >: 'set' and 'set'
```
On Branch -
```
>>> set1 = {1, 2, 3, 4, 5}
>>> set2 = {1, 2, 3}
>>> set2 < set1
True
>>> set3 = {2, 3, 4, 5}
>>> set1 > set3
True
```

Accordingly` issubset()`, `issuperset()` have been modified and all tests are passing.