### PR TITLE
Check the size of fillchar passed to str methods (ljust, rjust)

### DIFF
--- a/src/pocketpy.cpp
+++ b/src/pocketpy.cpp
@@ -734,7 +734,7 @@ void init_builtins(VM* _vm) {
         int delta = width - self.u8_length();
         if(delta <= 0) return args[0];
         const Str& fillchar = CAST(Str&, args[2]);
-        if (fillchar.size != 1) vm->TypeError("The fill character must be exactly one character long");
+        if (fillchar.u8_length() != 1) vm->TypeError("The fill character must be exactly one character long");
         SStream ss;
         ss << self;
         for(int i=0; i<delta; i++) ss << fillchar;
@@ -748,7 +748,7 @@ void init_builtins(VM* _vm) {
         int delta = width - self.u8_length();
         if(delta <= 0) return args[0];
         const Str& fillchar = CAST(Str&, args[2]);
-        if (fillchar.size != 1) vm->TypeError("The fill character must be exactly one character long");
+        if (fillchar.u8_length() != 1) vm->TypeError("The fill character must be exactly one character long");
         SStream ss;
         for(int i=0; i<delta; i++) ss << fillchar;
         ss << self;

--- a/src/pocketpy.cpp
+++ b/src/pocketpy.cpp
@@ -734,6 +734,7 @@ void init_builtins(VM* _vm) {
         int delta = width - self.u8_length();
         if(delta <= 0) return args[0];
         const Str& fillchar = CAST(Str&, args[2]);
+        if (fillchar.size != 1) vm->TypeError("The fill character must be exactly one character long");
         SStream ss;
         ss << self;
         for(int i=0; i<delta; i++) ss << fillchar;
@@ -747,6 +748,7 @@ void init_builtins(VM* _vm) {
         int delta = width - self.u8_length();
         if(delta <= 0) return args[0];
         const Str& fillchar = CAST(Str&, args[2]);
+        if (fillchar.size != 1) vm->TypeError("The fill character must be exactly one character long");
         SStream ss;
         for(int i=0; i<delta; i++) ss << fillchar;
         ss << self;

--- a/tests/04_str.py
+++ b/tests/04_str.py
@@ -157,8 +157,18 @@ assert b[5:2:-2] == [',', 'l']
 a = '123'
 assert a.rjust(5) == '  123'
 assert a.rjust(5, '0') == '00123'
+try:
+    a.rjust(5, '00')
+    exit(1)
+except TypeError:
+    pass
 assert a.ljust(5) == '123  '
 assert a.ljust(5, '0') == '12300'
+try:
+    a.ljust(5, '00')
+    exit(1)
+except TypeError:
+    pass
 
 assert '\x30\x31\x32' == '012'
 


### PR DESCRIPTION
A TypeError is raised when the length of the fillchar parameter is not equal to 1. 