### PR TITLE
Perform boundary checks before searching to prevent security vulnerabilities

### DIFF
--- a/src/pocketpy.cpp
+++ b/src/pocketpy.cpp
@@ -627,6 +627,7 @@ void init_builtins(VM* _vm) {
         const Str& self = _CAST(Str&, args[0]);
         const Str& value = CAST(Str&, args[1]);
         int start = CAST(int, args[2]);
+        if (start < 0) vm->ValueError("argument 'start' can't be negative");
         int index = self.index(value, start);
         if(index < 0) vm->ValueError("substring not found");
         return VAR(index);
@@ -636,6 +637,7 @@ void init_builtins(VM* _vm) {
         const Str& self = _CAST(Str&, args[0]);
         const Str& value = CAST(Str&, args[1]);
         int start = CAST(int, args[2]);
+		if (start < 0) vm->ValueError("argument 'start' can't be negative");
         return VAR(self.index(value, start));
     });
 

--- a/src/str.cpp
+++ b/src/str.cpp
@@ -266,6 +266,7 @@ int utf8len(unsigned char c, bool suppress){
     }
 
     int Str::index(const Str& sub, int start) const {
+        if (start < 0 || start >= this->u8_length()) return -1;
         auto p = std::search(data + start, data + size, sub.data, sub.data + sub.size);
         if(p == data + size) return -1;
         return p - data;

--- a/src/str.cpp
+++ b/src/str.cpp
@@ -266,7 +266,6 @@ int utf8len(unsigned char c, bool suppress){
     }
 
     int Str::index(const Str& sub, int start) const {
-        if (start < 0) start = 0;
         auto p = std::search(data + start, data + size, sub.data, sub.data + sub.size);
         if(p == data + size) return -1;
         return p - data;

--- a/src/str.cpp
+++ b/src/str.cpp
@@ -266,7 +266,7 @@ int utf8len(unsigned char c, bool suppress){
     }
 
     int Str::index(const Str& sub, int start) const {
-        if (start < 0 || start >= this->u8_length()) return -1;
+        if (start < 0) start = 0;
         auto p = std::search(data + start, data + size, sub.data, sub.data + sub.size);
         if(p == data + size) return -1;
         return p - data;

--- a/tests/04_str.py
+++ b/tests/04_str.py
@@ -250,7 +250,17 @@ try:
 except ValueError:
     pass
 
+try:
+    a.index('1', -1)
+    exit(1)
+except ValueError:
+    pass
+
 assert a.find('1') == 0
 assert a.find('1', 1) == -1
-assert a.find('1', -1000000) == 0
 
+try:
+    a.find('1', -1)
+    exit(1)
+except ValueError:
+    pass

--- a/tests/04_str.py
+++ b/tests/04_str.py
@@ -242,4 +242,5 @@ except ValueError:
 
 assert a.find('1') == 0
 assert a.find('1', 1) == -1
+assert a.find('1', -1000000) == 0
 


### PR DESCRIPTION
The current str.find doesn't perform boundary checks, which can lead to a crash or even security issues. 
A simple way to reproduce this bug: "hello".find('lo', -100000)
Instead, -1 should be returned in this case. 