### PR TITLE
raise a ZeroDivisionError when true-dividing by zero

### DIFF
--- a/src/pocketpy.cpp
+++ b/src/pocketpy.cpp
@@ -372,6 +372,7 @@ void init_builtins(VM* _vm) {
     });
     _vm->bind__truediv__(VM::tp_int, [](VM* vm, PyObject* _0, PyObject* _1) {
         f64 value = CAST_F(_1);
+        if (value == 0.) vm->ZeroDivisionError("division by zero");
         return VAR(_CAST(i64, _0) / value);
     });
 

--- a/tests/01_int.py
+++ b/tests/01_int.py
@@ -139,6 +139,12 @@ try:
 except ZeroDivisionError:
     pass
 
+try:
+    1 / 0
+    exit(1)
+except ZeroDivisionError:
+    pass
+
 assert not 1 < 2 > 3
 
 try:


### PR DESCRIPTION
Raise a ZeroDivisionError when true-dividing integers by zero as CPython has the same behavior. 