### PR TITLE
Emscripten build fix

### DIFF
--- a/include/pocketpy/vector.h
+++ b/include/pocketpy/vector.h
@@ -290,7 +290,7 @@ namespace pkpy
             const auto size = other.size();
             const auto capacity = other.capacity();
             m_begin = reinterpret_cast<T*>(other.is_small() ? m_buffer : std::malloc(sizeof(T) * capacity));
-            uninitialized_copy_n(other.begin, size, this->m_begin);
+            uninitialized_copy_n(other.m_begin, size, this->m_begin);
             m_end = m_begin + size;
             m_max = m_begin + capacity;
         }


### PR DESCRIPTION
I fixed a small typo that produced an error when compiling WASM for the [TIC-80](https://github.com/nesbox/TIC-80) project
<img width="1017" alt="Screenshot 2024-05-25 at 14 47 59" src="https://github.com/pocketpy/pocketpy/assets/1101448/5a8b9e5c-142e-487f-82b7-245c2f7aabe7">
