### PR TITLE
Fixes: warning: ISO C forbids empty initializer braces before C23

### DIFF
--- a/src/interpreter/ceval.c
+++ b/src/interpreter/ceval.c
@@ -906,7 +906,7 @@ pk_FrameResult pk_VM__run_top_frame(pk_VM* self) {
         c11__unreachedable();
 
     __ERROR:
-        pk_print_stack(self, frame, (Bytecode){});
+        pk_print_stack(self, frame, (Bytecode){0});
         py_BaseException__set_lineno(&self->curr_exception, Frame__lineno(frame), frame->co);
     __ERROR_RE_RAISE:
         do {} while(0);

--- a/src/interpreter/vm.c
+++ b/src/interpreter/vm.c
@@ -356,7 +356,7 @@ static bool
 }
 
 pk_FrameResult pk_VM__vectorcall(pk_VM* self, uint16_t argc, uint16_t kwargc, bool opcall) {
-    pk_print_stack(self, self->top_frame, (Bytecode){});
+    pk_print_stack(self, self->top_frame, (Bytecode){0});
 
     py_Ref p1 = self->stack.sp - kwargc * 2;
     py_Ref p0 = p1 - argc - 2;


### PR DESCRIPTION
Hi!

I has some issues with this empty initializer on msvc 19.38 and earlier. Using -std=c11 -pedantic on gcc will also show a warning. Putting a 0 in there should do the same thing, and makes Visual Studio happy.

See https://godbolt.org/z/Y4zK578Ea