### PR TITLE
fix win32 clang build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,10 +16,13 @@ else()
     message(WARNING ">> IPO disabled. You will not get the best performance.")
 endif()
 
+if(WIN32)
+    add_definitions(-D_CRT_SECURE_NO_WARNINGS)
+endif()
+
 if(MSVC)
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /utf-8 /jumptablerdata /GS-")
     add_compile_options(/wd4267 /wd4244)
-    add_definitions(-D_CRT_SECURE_NO_WARNINGS)
 
     if(NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
         set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /Ox")
@@ -54,7 +57,7 @@ endif()
 
 # PK_IS_MAIN determines whether the project is being used from root
 # or if it is added as a dependency (through add_subdirectory for example).
-if ("${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_CURRENT_SOURCE_DIR}")
+if("${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_CURRENT_SOURCE_DIR}")
     set(PK_IS_MAIN TRUE)
     option(PK_BUILD_SHARED_LIB "Build shared library" OFF)
     option(PK_BUILD_STATIC_LIB "Build static library" OFF)

--- a/src/modules/os.c
+++ b/src/modules/os.c
@@ -8,6 +8,7 @@
 
 #if PY_SYS_PLATFORM == 0
 #include <direct.h>
+#include <io.h>
 
 int platform_chdir(const char* path) { return _chdir(path); }
 


### PR DESCRIPTION
before:

```text
[61/63] Building C object CMakeFiles/main.dir/src2/main.c.obj
C:/Users/Trim21/proj/pocketpy/src2/main.c:14:18: warning: 'fopen' is deprecated: This function or variable may be unsafe. Consider using fopen_s instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details. [-Wdeprecated-declarations]
   14 |     FILE* file = fopen(path, "rb");
      |                  ^
C:\Program Files (x86)\Windows Kits\10\Include\10.0.22621.0\ucrt\stdio.h:212:20: note: 'fopen' has been explicitly marked deprecated here
  212 |     _Check_return_ _CRT_INSECURE_DEPRECATE(fopen_s)
      |                    ^
C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Tools\MSVC\14.41.34120\include\vcruntime.h:356:55: note: expanded from macro '_CRT_INSECURE_DEPRECATE'
  356 |         #define _CRT_INSECURE_DEPRECATE(_Replacement) _CRT_DEPRECATE_TEXT(    \
      |                                                       ^
C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Tools\MSVC\14.41.34120\include\vcruntime.h:346:47: note: expanded from macro '_CRT_DEPRECATE_TEXT'
  346 | #define _CRT_DEPRECATE_TEXT(_Text) __declspec(deprecated(_Text))
      |                                               ^
1 warning generated.
```

with `-D_CRT_SECURE_NO_WARNINGS`

```text
[57/63] Building C object CMakeFiles/pocketpy.dir/src/modules/os.c.obj
FAILED: CMakeFiles/pocketpy.dir/src/modules/os.c.obj
C:\Users\Trim21\scoop\apps\llvm\current\bin\clang.exe -DPK_BUILD_MODULE_LZ4=1 -D_CRT_SECURE_NO_WARNINGS -Dpocketpy_EXPORTS -IC:/Users/Trim21/proj/pocketpy/include -IC:/Users/Trim21/proj/pocketpy/3rd/lz4 -O0 -g -Xclang -gcodeview -D_DEBUG -D_DLL -D_MT -Xclang --dependent-lib=msvcrtd -std=gnu11 -flto=thin -MD -MT CMakeFiles/pocketpy.dir/src/modules/os.c.obj -MF CMakeFiles\pocketpy.dir\src\modules\os.c.obj.d -o CMakeFiles/pocketpy.dir/src/modules/os.c.obj -c C:/Users/Trim21/proj/pocketpy/src/modules/os.c
C:/Users/Trim21/proj/pocketpy/src/modules/os.c:16:54: error: call to undeclared function '_access'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
   16 | bool platform_path_exists(const char* path) { return _access(path, 0) == 0; }
      |                                                      ^
1 error generated.
```

I'm using `cmake . -B build -G Ninja -DCMAKE_BUILD_TYPE=Release` and looks like ninja is not a factor in this case
