### PR TITLE
add pybind11 implementation for module reload

### DIFF
--- a/include/pybind11/internal/module.h
+++ b/include/pybind11/internal/module.h
@@ -19,6 +19,11 @@ class module_ : public object {
         return steal<module_>(m);
     }
 
+    void reload() {
+        bool ok = py_importlib_reload(ptr());
+        if(!ok) { throw error_already_set(); }
+    }
+
     module_ def_submodule(const char* name, const char* doc = nullptr) {
         // auto package = (attr("__package__").cast<std::string>() += ".") +=
         // attr("__name__").cast<std::string_view>();


### PR DESCRIPTION
Adds `py::module` instance method `reload` as described [here](https://pybind11.readthedocs.io/en/stable/advanced/embedding.html#:~:text=Modules%20can%20be%20reloaded%20using%20module_%3A%3Areload()) based on the reference pybind11 implementation [here](https://github.com/pybind/pybind11/blob/945e251a6ce7273058b36214d94415e9c9530b8e/include/pybind11/pybind11.h#L1253-L1259).