### PR TITLE
Add builtins.dir()

### DIFF
--- a/amalgamate.py
+++ b/amalgamate.py
@@ -5,7 +5,8 @@ import sys
 import time
 from typing import List, Dict
 
-assert os.system("python prebuild.py") == 0
+if os.system("python prebuild.py") != 0:
+    assert os.system("python3 prebuild.py") == 0
 
 ROOT = 'include/pocketpy'
 PUBLIC_HEADERS = ['config.h', 'export.h', 'linalg.h', 'pocketpy.h']

--- a/amalgamate.py
+++ b/amalgamate.py
@@ -5,8 +5,7 @@ import sys
 import time
 from typing import List, Dict
 
-if os.system("python prebuild.py") != 0:
-    assert os.system("python3 prebuild.py") == 0
+assert os.system("python prebuild.py") == 0
 
 ROOT = 'include/pocketpy'
 PUBLIC_HEADERS = ['config.h', 'export.h', 'linalg.h', 'pocketpy.h']

--- a/python/builtins.py
+++ b/python/builtins.py
@@ -85,18 +85,18 @@ def dir(obj=None):
     if obj is None:
         return list(globals().keys())
     
-    if hasattr(obj, "__dir__"):
-        return obj.__dir__()
-    
     attributes = set()
-    # Set object attributes.
+    
+    if not isinstance(obj, type):
+        if hasattr(obj, "__dir__"):
+            return sorted(obj.__dir__())
+        attributes.update(dir(type(obj)))
+    
     if hasattr(obj, "__dict__"):
         attributes.update(obj.__dict__.keys())
     
-    # Set type attributes.
-    if not isinstance(obj, type):
-        if hasattr(type(obj), "__dict__"):
-            attributes.update(type(obj).__dict__.keys())
+    if hasattr(obj, "__base__") and obj.__base__ is not None:
+        attributes.update(dir(obj.__base__))
     
     return sorted(attributes)
 

--- a/python/builtins.py
+++ b/python/builtins.py
@@ -82,24 +82,11 @@ def sorted(iterable, key=None, reverse=False):
     return a
 
 def dir(obj=None):
-    """
-    dir([object]) -> list of strings
-    
-    If called without an argument, return the names in the current scope.
-    Else, return an alphabetized list of names comprising (some of) the attributes
-    of the given object, and of attributes reachable from it.
-    If the object supplies a method named __dir__, it will be used; otherwise
-    the default dir() logic is used and returns:
-      for a module object: the module's attributes.
-      for a class object: its attributes.
-      for any other object: its attributes, its class's attributes.
-    """
-    
     if obj is None:
         return list(globals().keys())
     
     if hasattr(obj, "__dir__"):
-        return obj.__dir__
+        return obj.__dir__()
     
     attributes = set()
     # Set object attributes.

--- a/python/builtins.py
+++ b/python/builtins.py
@@ -81,6 +81,39 @@ def sorted(iterable, key=None, reverse=False):
     a.sort(key=key, reverse=reverse)
     return a
 
+def dir(obj=None):
+    """
+    dir([object]) -> list of strings
+    
+    If called without an argument, return the names in the current scope.
+    Else, return an alphabetized list of names comprising (some of) the attributes
+    of the given object, and of attributes reachable from it.
+    If the object supplies a method named __dir__, it will be used; otherwise
+    the default dir() logic is used and returns:
+      for a module object: the module's attributes.
+      for a class object: its attributes.
+      for any other object: its attributes, its class's attributes.
+    """
+    
+    if obj is None:
+        return list(globals().keys())
+    
+    if hasattr(obj, "__dir__"):
+        return obj.__dir__
+    
+    attributes = set()
+    # Set object attributes.
+    if hasattr(obj, "__dict__"):
+        attributes.update(obj.__dict__.keys())
+    
+    # Set type attributes.
+    if not isinstance(obj, type):
+        if hasattr(type(obj), "__dict__"):
+            attributes.update(type(obj).__dict__.keys())
+    
+    return sorted(attributes)
+
+
 ##### str #####
 def __format_string(self: str, *args, **kwargs) -> str:
     def tokenizeString(s: str):

--- a/src/public/py_mappingproxy.c
+++ b/src/public/py_mappingproxy.c
@@ -63,6 +63,19 @@ static bool namedict_items(int argc, py_Ref argv) {
     return true;
 }
 
+static bool namedict_keys(int argc, py_Ref argv) {
+    PY_CHECK_ARGC(1);
+    py_Ref object = py_getslot(argv, 0);
+    NameDict* dict = PyObject__dict(object->_obj);
+    py_newtuple(py_retval(), dict->length);
+    for (int i = 0; i < dict->length; i++) {
+        py_Ref key_ref = py_tuple_getitem(py_retval(), i);
+        NameDict_KV* kv = c11__at(NameDict_KV, dict, i);
+        py_newstr(key_ref, py_name2str(kv->key));
+    }
+    return true;
+}
+
 static bool namedict_clear(int argc, py_Ref argv) {
     PY_CHECK_ARGC(1);
     py_Ref object = py_getslot(argv, 0);
@@ -81,6 +94,7 @@ py_Type pk_namedict__register() {
     py_bindmagic(type, __contains__, namedict__contains__);
     py_newnone(py_tpgetmagic(type, __hash__));
     py_bindmethod(type, "items", namedict_items);
+    py_bindmethod(type, "keys", namedict_keys);
     py_bindmethod(type, "clear", namedict_clear);
     return type;
 }

--- a/tests/70_builtins.py
+++ b/tests/70_builtins.py
@@ -51,19 +51,18 @@ assert not all([False, False])
 assert list(enumerate([1,2,3])) == [(0,1), (1,2), (2,3)]
 assert list(enumerate([1,2,3], 1)) == [(1,1), (2,2), (3,3)]
 
-class C1:
-    def c(): ...
+assert "__name__" in dir()
 
-class C2(C1):
-    a = 'a'
+class Base:
+    def inherited(): ...
+
+class Test(Base):
+    cls_attr = 'a'
     def __init__(self):
-        self.b = 1
+        self.self_attr = 1
+assert {"self_attr", "cls_attr", "inherited"}.issubset(dir(Test()))
 
-class C3:
+class CustomDir:
     def __dir__(self):
         return ["custom"]
-
-assert "__name__" in dir()
-assert "a", "b" in dir(C2())
-assert "c" in dir(C2())
-assert ["custom"] == dir(C3())
+assert ["custom"] == dir(CustomDir())

--- a/tests/70_builtins.py
+++ b/tests/70_builtins.py
@@ -50,3 +50,20 @@ assert not all([False, False])
 
 assert list(enumerate([1,2,3])) == [(0,1), (1,2), (2,3)]
 assert list(enumerate([1,2,3], 1)) == [(1,1), (2,2), (3,3)]
+
+class C1:
+    def c(): ...
+
+class C2(C1):
+    a = 'a'
+    def __init__(self):
+        self.b = 1
+
+class C3:
+    def __dir__(self):
+        return ["custom"]
+
+assert "__name__" in dir()
+assert "a", "b" in dir(C2())
+assert "c" in dir(C2())
+assert ["custom"] == dir(C3())


### PR DESCRIPTION
- Adds namedict.keys function so `__dict__.keys()` can be evaluated.
- Adds builtins.dir to list all attributes of an object.

I would like to implement the `rlcompleter` lib in some form in the future to have a basic autocompletion tool