### PR TITLE
Safe exec proposal

### DIFF
--- a/include/pocketpy/interpreter/vm.h
+++ b/include/pocketpy/interpreter/vm.h
@@ -26,6 +26,9 @@ typedef struct VM {
     py_TValue builtins;  // builtins module
     py_TValue main;      // __main__ module
 
+    py_i64 max_steps;
+    py_i64 used_steps;
+
     py_Callbacks callbacks;
 
     py_TValue ascii_literals[128+1];

--- a/include/pocketpy/pocketpy.h
+++ b/include/pocketpy/pocketpy.h
@@ -735,6 +735,7 @@ enum py_PredefinedTypes {
     tp_ImportError,
     tp_AssertionError,
     tp_KeyError,
+    tp_Timeout,
     /* linalg */
     tp_vec2,
     tp_vec3,

--- a/src/interpreter/ceval.c
+++ b/src/interpreter/ceval.c
@@ -253,6 +253,20 @@ FrameResult VM__run_top_frame(VM* self) {
                 }
                 if(res == -1) goto __ERROR;
                 // builtins
+                if (self->max_steps > 0) {
+                    int res = Frame__getglobal(frame, py_name("__builtins__"));
+                    if (res == 1) {
+                        py_Ref builtins = &self->last_retval;
+                        if(!py_istype(builtins, tp_dict)) { return TypeError("__builtins__ must be a dict object"); }
+                        res = py_dict_getitem(builtins, py_name2ref(name));
+                        if (res == 1) {
+                            PUSH(&self->last_retval);
+                            DISPATCH();
+                        }
+                    }
+                    NameError(name);
+                    goto __ERROR;
+                }
                 py_Ref tmp = py_getdict(&self->builtins, name);
                 if(tmp != NULL) {
                     PUSH(tmp);
@@ -275,6 +289,20 @@ FrameResult VM__run_top_frame(VM* self) {
                 }
                 if(res == -1) goto __ERROR;
 
+                if (self->max_steps > 0) {
+                    int res = Frame__getglobal(frame, py_name("__builtins__"));
+                    if (res == 1) {
+                        py_Ref builtins = &self->last_retval;
+                        if(!py_istype(builtins, tp_dict)) { return TypeError("__builtins__ must be a dict object"); }
+                        res = py_dict_getitem(builtins, py_name2ref(name));
+                        if (res == 1) {
+                            PUSH(&self->last_retval);
+                            DISPATCH();
+                        }
+                    }
+                    NameError(name);
+                    goto __ERROR;
+                }
                 tmp = py_getdict(&self->builtins, name);
                 if(tmp != NULL) {
                     PUSH(tmp);
@@ -291,6 +319,20 @@ FrameResult VM__run_top_frame(VM* self) {
                     DISPATCH();
                 }
                 if(res == -1) goto __ERROR;
+                if (self->max_steps > 0) {
+                    int res = Frame__getglobal(frame, py_name("__builtins__"));
+                    if (res == 1) {
+                        py_Ref builtins = &self->last_retval;
+                        if(!py_istype(builtins, tp_dict)) { return TypeError("__builtins__ must be a dict object"); }
+                        res = py_dict_getitem(builtins, py_name2ref(name));
+                        if (res == 1) {
+                            PUSH(&self->last_retval);
+                            DISPATCH();
+                        }
+                    }
+                    NameError(name);
+                    goto __ERROR;
+                }
                 py_Ref tmp = py_getdict(&self->builtins, name);
                 if(tmp != NULL) {
                     PUSH(tmp);
@@ -322,6 +364,20 @@ FrameResult VM__run_top_frame(VM* self) {
                     DISPATCH();
                 }
                 if(res == -1) goto __ERROR;
+                if (self->max_steps > 0) {
+                    int res = Frame__getglobal(frame, py_name("__builtins__"));
+                    if (res == 1) {
+                        py_Ref builtins = &self->last_retval;
+                        if(!py_istype(builtins, tp_dict)) { return TypeError("__builtins__ must be a dict object"); }
+                        res = py_dict_getitem(builtins, py_name2ref(name));
+                        if (res == 1) {
+                            PUSH(&self->last_retval);
+                            DISPATCH();
+                        }
+                    }
+                    NameError(name);
+                    goto __ERROR;
+                }
                 tmp = py_getdict(&self->builtins, name);
                 if(tmp) {
                     PUSH(tmp);

--- a/src/interpreter/ceval.c
+++ b/src/interpreter/ceval.c
@@ -109,6 +109,15 @@ FrameResult VM__run_top_frame(VM* self) {
             goto __ERROR;
         }
 
+        if (self->max_steps > 0) {
+          if (self->used_steps >= self->max_steps) {
+            py_exception(tp_Timeout, "execution timed out");
+            goto __ERROR;
+          }
+          self->used_steps++;
+        }
+
+
         switch((Opcode)byte.op) {
             case OP_NO_OP: DISPATCH();
             /*****************************************/

--- a/src/interpreter/vm.c
+++ b/src/interpreter/vm.c
@@ -176,6 +176,7 @@ void VM__ctor(VM* self) {
     INJECT_BUILTIN_EXC(ImportError, tp_Exception);
     INJECT_BUILTIN_EXC(AssertionError, tp_Exception);
     INJECT_BUILTIN_EXC(KeyError, tp_Exception);
+    INJECT_BUILTIN_EXC(Timeout, tp_Exception);
 
 #undef INJECT_BUILTIN_EXC
 #undef validate

--- a/src/public/modules.c
+++ b/src/public/modules.c
@@ -69,6 +69,10 @@ int load_module_from_dll_desktop_only(const char* path) PY_RAISE PY_RETURN;
 
 int py_import(const char* path_cstr) {
     VM* vm = pk_current_vm;
+    if (vm->max_steps > 0) {
+      ImportError("not allowed in safe context");
+      return -1;
+    }
     c11_sv path = {path_cstr, strlen(path_cstr)};
     if(path.size == 0) return ValueError("empty module name");
 

--- a/src/public/modules.c
+++ b/src/public/modules.c
@@ -612,6 +612,20 @@ static bool builtins_exec(int argc, py_Ref argv) {
     return ok;
 }
 
+static bool builtins_exec_jailed(int argc, py_Ref argv) {
+    VM* vm = pk_current_vm;
+    PY_CHECK_ARG_TYPE(0, tp_int);
+    int was_jailed = (vm->max_steps > 0);
+    if (!was_jailed) {
+      vm->max_steps = py_toint(py_arg(0));
+      vm->used_steps = 0;
+    }
+    bool ok = _builtins_execdyn("exec", argc - 1, argv + 1, EXEC_MODE);
+    if (!was_jailed) vm->max_steps = 0;
+    py_newnone(py_retval());
+    return ok;
+}
+
 static bool builtins_eval(int argc, py_Ref argv) {
     return _builtins_execdyn("eval", argc, argv, EVAL_MODE);
 }
@@ -755,6 +769,7 @@ py_TValue pk_builtins__register() {
     py_bindfunc(builtins, "globals", builtins_globals);
     py_bindfunc(builtins, "locals", builtins_locals);
     py_bindfunc(builtins, "exec", builtins_exec);
+    py_bindfunc(builtins, "exec_jailed", builtins_exec_jailed);
     py_bindfunc(builtins, "eval", builtins_eval);
     py_bindfunc(builtins, "compile", builtins_compile);
 

--- a/tests/66_eval.py
+++ b/tests/66_eval.py
@@ -93,10 +93,12 @@ res = []
 exec_jailed(100000, code, {'__builtins__': {'z': lambda x: res.append(x)}})
 assert res == [1, 2]
 
-code = '''
-print(1)
-'''
 try:
-  exec_jailed(100000, code, {'__builtins__': {}})
+  exec_jailed(100000, 'print(1)', {'__builtins__': {}})
 except NameError:
+  pass
+
+try:
+  exec_jailed(100000, 'import sys')
+except ImportError:
   pass

--- a/tests/66_eval.py
+++ b/tests/66_eval.py
@@ -82,3 +82,21 @@ try:
   exec_jailed(100000, code)
 except Timeout:
   pass
+
+code = '''
+def f():
+  z(1)
+f()
+z(2)
+'''
+res = []
+exec_jailed(100000, code, {'__builtins__': {'z': lambda x: res.append(x)}})
+assert res == [1, 2]
+
+code = '''
+print(1)
+'''
+try:
+  exec_jailed(100000, code, {'__builtins__': {}})
+except NameError:
+  pass

--- a/tests/66_eval.py
+++ b/tests/66_eval.py
@@ -74,3 +74,11 @@ exec(code, {'x': 42, 'res': res})
 assert res == [42, 42]
 assert x == 33
 
+code = '''
+while True:
+  pass
+'''
+try:
+  exec_jailed(100000, code)
+except Timeout:
+  pass


### PR DESCRIPTION
This is a proposal for implementing safe execution of user-provided code. My intent is not to get this PR accepted, but just to illustrate how a jailed exec could be implemented.

It adds a new builtin: exec_jailed(num_interpreter_steps, code, globals, locals).

Added limits:
- imports are not allowed
- builtins are read from the `__builtins__` global
- raises a new Timeout exception after the interpreter has run num_steps

I am happy to discuss this proposal and ideas on how to jailbreak it.