### PR TITLE
Add context-aware integer type checking for improved error messages

### DIFF
--- a/include/pocketpy/pocketpy.h
+++ b/include/pocketpy/pocketpy.h
@@ -316,6 +316,19 @@ PK_API bool py_checkinstance(py_Ref self, py_Type type) PY_RAISE;
 #define py_checkbool(self) py_checktype(self, tp_bool)
 #define py_checkstr(self) py_checktype(self, tp_str)
 
+// Internal helper function that checks if a value is an int and, if not, returns an error with context.
+static inline bool py_checkint_with_context(py_Ref self, py_Type type, const char* func, int line) {
+    if (self->type == type) {
+        return true;
+    }
+    // TypeError is assumed to be a function that prints an error message and returns false.
+    return TypeError("In %s (line %d): expected '%t', got '%t'", func, line, type, self->type);
+}
+
+// Macro to use for additional context when checking int arguments.
+#define PY_CHECK_INT_ARG(i) \
+    if (!py_checkint_with_context(py_arg(i), tp_int, __func__, __LINE__)) return false;
+
 /************* References *************/
 
 /// Get the i-th register.


### PR DESCRIPTION
Currently, when a type error occurs due to an incorrect int argument, the error message only shows the expected and received types. This makes it harder to pinpoint which function and line triggered the error.

This PR adds a helper function `py_checkint_with_context()` and a corresponding macro `PY_CHECK_INT_ARG` that use `__func__ `and `__LINE__ `to include the caller's function name and line number in the error message. This enhancement provides clearer context during debugging without altering existing behavior. The new helper is defined near the existing type-check functions in pocketpy.h for consistency.

PS : I did not modify the existing `py_checktype()` to maintain compatibility with the current codebase and seek approval for this format. This change specifically targets **int type** checks and can be adopted gradually where improved context is needed.