### PR TITLE
Fixed typos in documentation, comments, and code

### DIFF
--- a/docs/bindings-cpp.md
+++ b/docs/bindings-cpp.md
@@ -288,4 +288,4 @@ Need further discussion.
 
 - in-place operators, such as `+=`, `-=`, `*=`, etc., are not supported in pocketpy.
 
-- thre return value of `globals` is immutable in pocketpy.
+- the return value of `globals` is immutable in pocketpy.

--- a/include/pocketpy/pocketpy.h
+++ b/include/pocketpy/pocketpy.h
@@ -197,7 +197,7 @@ PK_API py_Name py_newfunction(py_OutRef out,
 /// Create a `boundmethod` object.
 PK_API void py_newboundmethod(py_OutRef out, py_Ref self, py_Ref func);
 
-/************* Name Convertions *************/
+/************* Name Conversions *************/
 
 /// Convert a null-terminated string to a name.
 PK_API py_Name py_name(const char*);
@@ -506,7 +506,7 @@ PK_API int py_import(const char* path) PY_RAISE PY_RETURN;
 
 /// Raise an exception by type and message. Always return false.
 PK_API bool py_exception(py_Type type, const char* fmt, ...) PY_RAISE;
-/// Raise an expection object. Always return false.
+/// Raise an exception object. Always return false.
 PK_API bool py_raise(py_Ref) PY_RAISE;
 /// Print the current exception.
 /// The exception will be set as handled.

--- a/include/pocketpy/xmacros/smallmap.h
+++ b/include/pocketpy/xmacros/smallmap.h
@@ -18,7 +18,7 @@
 #define equal(a, b) ((a) == (b))
 #endif
 
-/* Temprary macros */
+/* Temporary macros */
 #define partial_less(a, b) less((a).key, (b))
 #define CONCAT(A, B) CONCAT_(A, B)
 #define CONCAT_(A, B) A##B

--- a/src/interpreter/ceval.c
+++ b/src/interpreter/ceval.c
@@ -1343,14 +1343,14 @@ static bool stack_format_object(VM* self, c11_sv spec) {
         } else {
             // {10.2f}
             IntParsingResult res = c11__parse_uint(c11_sv__slice2(spec, 0, dot), &width, 10);
-            if(res != IntParsing_SUCCESS) return ValueError("invalid format specifer");
+            if(res != IntParsing_SUCCESS) return ValueError("invalid format specifier");
         }
         IntParsingResult res = c11__parse_uint(c11_sv__slice(spec, dot + 1), &precision, 10);
-        if(res != IntParsing_SUCCESS) return ValueError("invalid format specifer");
+        if(res != IntParsing_SUCCESS) return ValueError("invalid format specifier");
     } else {
         // {10s}
         IntParsingResult res = c11__parse_uint(spec, &width, 10);
-        if(res != IntParsing_SUCCESS) return ValueError("invalid format specifer");
+        if(res != IntParsing_SUCCESS) return ValueError("invalid format specifier");
         precision = -1;
     }
 

--- a/src/interpreter/vm.c
+++ b/src/interpreter/vm.c
@@ -147,7 +147,7 @@ void VM__ctor(VM* self) {
 
     self->builtins = pk_builtins__register();
 
-    // inject some builtin expections
+    // inject some builtin exceptions
 #define INJECT_BUILTIN_EXC(name, TBase)                                                            \
     do {                                                                                           \
         py_Type type = pk_newtype(#name, TBase, &self->builtins, NULL, false, true);               \

--- a/src/modules/pickle.c
+++ b/src/modules/pickle.c
@@ -703,7 +703,7 @@ bool py_pickle_loads_body(const unsigned char* p, int memo_length, c11_smallmap_
 static bool PickleObject__py_submit(PickleObject* self, py_OutRef out) {
     c11_sbuf cleartext;
     c11_sbuf__ctor(&cleartext);
-    // line 1: type mappping
+    // line 1: type mapping
     for(py_Type type = 0; type < self->used_types_length; type++) {
         if(self->used_types[type]) {
             c11_sbuf__write_int(&cleartext, type);

--- a/src/public/py_exception.c
+++ b/src/public/py_exception.c
@@ -153,7 +153,7 @@ void py_clearexc(py_StackRef p0) {
     VM* vm = pk_current_vm;
     vm->curr_exception = *py_NIL();
     vm->is_curr_exc_handled = false;
-    /* Don't clear this, because StopIteration() may corrupt the class defination */
+    /* Don't clear this, because StopIteration() may corrupt the class definition */
     // vm->__curr_class = NULL;
     vm->__curr_function = NULL;
     if(p0) vm->stack.sp = p0;


### PR DESCRIPTION
This small contribution improves spelling across documentation, comments, and code as I familiarize myself with the org’s CI/CD process.
Looking forward to making more meaningful contributions!

In the future, we could integrate codespell into CI/CD (excluding certain files). Let me know if you'd like me to proceed with that.