### PR TITLE
Fix line number reporting in trace functions for function calls

### DIFF
--- a/src/interpreter/frame.c
+++ b/src/interpreter/frame.c
@@ -121,8 +121,11 @@ void Frame__gc_mark(py_Frame* self) {
 
 int Frame__lineno(const py_Frame* self) {
     int ip = self->ip;
-    if(ip < 0) return 0;
-    return c11__getitem(BytecodeEx, &self->co->codes_ex, ip).lineno;
+    if(ip >= 0)
+        return c11__getitem(BytecodeEx, &self->co->codes_ex, ip).lineno;
+    if(!self->is_locals_special)
+        return self->co->start_line;
+    return 0;
 }
 
 int Frame__iblock(const py_Frame* self) {


### PR DESCRIPTION
When a trace function is set using `settrace`, we can access the current file name and line number through `py_Frame_sourceloc`. However, during function calls, the line number is returned as 0. This PR fixes this issue to return the correct line number.

