### PR TITLE
Remove redundant CMake setup steps in pybind11 workflow

### DIFF
--- a/.github/workflows/pybind11.yml
+++ b/.github/workflows/pybind11.yml
@@ -24,9 +24,6 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y gcc g++
 
-      - name: Set up CMake
-        uses: jwlawson/actions-setup-cmake@v1.10
-
       - name: Test
         run: |
           cd include/pybind11/tests
@@ -42,9 +39,6 @@ jobs:
 
       - name: Set up MSVC
         uses: ilammy/msvc-dev-cmd@v1
-
-      - name: Set up CMake
-        uses: jwlawson/actions-setup-cmake@v1.10
 
       - name: Test
         run: |
@@ -64,9 +58,6 @@ jobs:
           brew install llvm
           echo 'export PATH="/usr/local/opt/llvm/bin:$PATH"' >> ~/.zshrc
           source ~/.zshrc
-
-      - name: Set up CMake
-        uses: jwlawson/actions-setup-cmake@v1.10
 
       - name: Test
         run: |


### PR DESCRIPTION
Since CMake is already pre-installed in the workflow environment and the version configuration may be outdated, this PR removes the unnecessary CMake installation step from the workflow configuration.