### PR TITLE
fix: handle hex escapes in strings and reject invalid escapes

### DIFF
--- a/src/compiler/lexer.c
+++ b/src/compiler/lexer.c
@@ -280,10 +280,22 @@ static Error* _eat_string(Lexer* self, c11_sbuf* buff, char quote, enum StringTy
                 case 'x': {
                     char hex[3] = {eatchar(self), eatchar(self), '\0'};
                     int code;
-                    if(sscanf(hex, "%x", &code) != 1) {
-                        return LexerError(self, "invalid hex char");
+                    if (sscanf(hex, "%x", &code) != 1 || code > 0xFF) {
+                        return LexerError(self, "invalid hex escape");
                     }
-                    c11_sbuf__write_char(buff, (char)code);
+                    if (type == NORMAL_BYTES) {
+                        // Bytes literals: write raw byte
+                        c11_sbuf__write_char(buff, (char)code);
+                    } else {
+                        // Regular strings: encode as UTF-8
+                        if (code <= 0x7F) {
+                            c11_sbuf__write_char(buff, (char)code);
+                        } else {
+                            // Encode as 2-byte UTF-8 for code points 0x80-0xFF
+                            c11_sbuf__write_char(buff, 0xC0 | (code >> 6));        // Leading byte
+                            c11_sbuf__write_char(buff, 0x80 | (code & 0x3F));      // Continuation byte
+                        }
+                    }
                 } break;
                 default: return LexerError(self, "invalid escape char");
             }


### PR DESCRIPTION
 Fixes #331: Correctly handle `\x` escapes in string literals.  
- Encodes hex values as UTF-8 for strings, ensuring valid lengths.  
- Rejects invalid hex escapes (e.g., `\xgg`). 