### PR TITLE
Fix getchar() helper

### DIFF
--- a/include/pocketpy/pocketpy.h
+++ b/include/pocketpy/pocketpy.h
@@ -71,7 +71,7 @@ typedef struct py_Callbacks {
     /// Flush the output buffer of `print`.
     void (*flush)();
     /// Used by `input` to get a character.
-    int (*getchar)();
+    int (*getch)();
 } py_Callbacks;
 
 /// Native function signature.

--- a/src/interpreter/vm.c
+++ b/src/interpreter/vm.c
@@ -76,7 +76,7 @@ void VM__ctor(VM* self) {
     self->callbacks.importfile = pk_default_importfile;
     self->callbacks.print = pk_default_print;
     self->callbacks.flush = pk_default_flush;
-    self->callbacks.getchar = getchar;
+    self->callbacks.getch = getchar;
 
     self->last_retval = *py_NIL();
     self->curr_exception = *py_NIL();
@@ -822,7 +822,7 @@ int py_replinput(char* buf, int max_size) {
     printf(">>> ");
 
     while(true) {
-        int c = pk_current_vm->callbacks.getchar();
+        int c = pk_current_vm->callbacks.getch();
         if(c == EOF) return -1;
 
         if(c == '\n') {

--- a/src/public/modules.c
+++ b/src/public/modules.c
@@ -205,7 +205,7 @@ static bool builtins_input(int argc, py_Ref argv) {
     c11_sbuf buf;
     c11_sbuf__ctor(&buf);
     while(true) {
-        int c = py_callbacks()->getchar();
+        int c = py_callbacks()->getch();
         if(c == '\n' || c == '\r') break;
         if(c == EOF) break;
         c11_sbuf__write_char(&buf, c);


### PR DESCRIPTION
The getchar() function is defined as a macro in uClibc, raising the next following errors:

>>> pocketpy 2.0.8 Building
GIT_DIR=. PATH="/builds/jolivain/buildroot/br-test-pkg/bootlin-arcle-hs38-uclibc/host/bin:/builds/jolivain/buildroot/br-test-pkg/bootlin-arcle-hs38-uclibc/host/sbin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"  /usr/bin/cmake --build /builds/jolivain/buildroot/br-test-pkg/bootlin-arcle-hs38-uclibc/build/pocketpy-2.0.8/ -j3 -- [ 50%] Building C object CMakeFiles/pocketpy.dir/Unity/unity_pocketpy_c.c.o In file included from /builds/jolivain/buildroot/br-test-pkg/bootlin-arcle-hs38-uclibc/host/arc-buildroot-linux-uclibc/sysroot/usr/include/stdio.h:71,
                 from /builds/jolivain/buildroot/br-test-pkg/bootlin-arcle-hs38-uclibc/build/pocketpy-2.0.8/include/pocketpy/common/utils.h:3,
                 from /builds/jolivain/buildroot/br-test-pkg/bootlin-arcle-hs38-uclibc/build/pocketpy-2.0.8/include/pocketpy/common/str.h:4,
                 from /builds/jolivain/buildroot/br-test-pkg/bootlin-arcle-hs38-uclibc/build/pocketpy-2.0.8/include/pocketpy/common/smallmap.h:4,
                 from /builds/jolivain/buildroot/br-test-pkg/bootlin-arcle-hs38-uclibc/build/pocketpy-2.0.8/src/common/smallmap.c:1,
                 from /builds/jolivain/buildroot/br-test-pkg/bootlin-arcle-hs38-uclibc/build/pocketpy-2.0.8/CMakeFiles/pocketpy.dir/Unity/unity_pocketpy_c.c:9:
/builds/jolivain/buildroot/br-test-pkg/bootlin-arcle-hs38-uclibc/build/pocketpy-2.0.8/src/interpreter/vm.c: In function ‘py_replinput’: /builds/jolivain/buildroot/br-test-pkg/bootlin-arcle-hs38-uclibc/build/pocketpy-2.0.8/src/interpreter/vm.c:813:42: error: expected identifier before ‘(’ token
  813 |         int c = pk_current_vm->callbacks.getchar();
      |                                          ^~~~~~~
/builds/jolivain/buildroot/br-test-pkg/bootlin-arcle-hs38-uclibc/build/pocketpy-2.0.8/src/interpreter/vm.c:813:42: error: expected statement before ‘)’ token
  813 |         int c = pk_current_vm->callbacks.getchar();
      |                                          ^~~~~~~
/builds/jolivain/buildroot/br-test-pkg/bootlin-arcle-hs38-uclibc/build/pocketpy-2.0.8/src/interpreter/vm.c:813:42: error: expected statement before ‘)’ token
  813 |         int c = pk_current_vm->callbacks.getchar();

Link: https://gitlab.com/jolivain/buildroot/-/pipelines/1847795347
Link: https://gitlab.com/jolivain/buildroot/-/jobs/10217736977