### PR TITLE
Fix context manager __exit__ not being called on exception (#395)

### DIFF
--- a/src/compiler/compiler.c
+++ b/src/compiler/compiler.c
@@ -2803,6 +2803,8 @@ static Error* compile_stmt(Compiler* self) {
         case TK_WITH: {
             check(EXPR(self));  // [ <expr> ]
             Ctx__s_emit_top(ctx());
+            // Save context manager for later __exit__ call
+            Ctx__emit_(ctx(), OP_DUP_TOP, BC_NOARG, prev()->line);
             Ctx__enter_block(ctx(), CodeBlockType_WITH);
             NameExpr* as_name = NULL;
             if(match(TK_AS)) {
@@ -2811,17 +2813,33 @@ static Error* compile_stmt(Compiler* self) {
                 as_name = NameExpr__new(prev()->line, name, name_scope(self));
             }
             Ctx__emit_(ctx(), OP_WITH_ENTER, BC_NOARG, prev()->line);
-            // [ <expr> <expr>.__enter__() ]
             if(as_name) {
                 bool ok = vtemit_store((Expr*)as_name, ctx());
                 vtdelete((Expr*)as_name);
                 if(!ok) return SyntaxError(self, "invalid syntax");
             } else {
-                // discard `__enter__()`'s return value
                 Ctx__emit_(ctx(), OP_POP_TOP, BC_NOARG, BC_KEEPLINE);
             }
+            // Wrap body in try-except to ensure __exit__ is called even on exception
+            Ctx__enter_block(ctx(), CodeBlockType_TRY);
+            Ctx__emit_(ctx(), OP_BEGIN_TRY, BC_NOARG, prev()->line);
             check(compile_block_body(self));
+            Ctx__emit_(ctx(), OP_END_TRY, BC_NOARG, BC_KEEPLINE);
+            // Normal exit: call __exit__(None, None, None)
+            Ctx__emit_(ctx(), OP_LOAD_NONE, BC_NOARG, prev()->line);
+            Ctx__emit_(ctx(), OP_LOAD_NONE, BC_NOARG, prev()->line);
+            Ctx__emit_(ctx(), OP_LOAD_NONE, BC_NOARG, prev()->line);
             Ctx__emit_(ctx(), OP_WITH_EXIT, BC_NOARG, prev()->line);
+            int jump_patch = Ctx__emit_(ctx(), OP_JUMP_FORWARD, BC_NOARG, BC_KEEPLINE);
+            Ctx__exit_block(ctx());
+            // Exception handler: call __exit__ with exception info, then re-raise
+            Ctx__emit_(ctx(), OP_PUSH_EXCEPTION, BC_NOARG, BC_KEEPLINE);
+            Ctx__emit_(ctx(), OP_LOAD_NONE, BC_NOARG, BC_KEEPLINE);  // exc_type
+            Ctx__emit_(ctx(), OP_ROT_TWO, BC_NOARG, BC_KEEPLINE);     // reorder: [cm, None, exc]
+            Ctx__emit_(ctx(), OP_LOAD_NONE, BC_NOARG, BC_KEEPLINE);  // exc_tb
+            Ctx__emit_(ctx(), OP_WITH_EXIT, BC_NOARG, prev()->line);
+            Ctx__emit_(ctx(), OP_RE_RAISE, BC_NOARG, BC_KEEPLINE);
+            Ctx__patch_jump(ctx(), jump_patch);
             Ctx__exit_block(ctx());
         } break;
         /*************************************************/

--- a/tests/520_context.py
+++ b/tests/520_context.py
@@ -27,4 +27,29 @@ assert path == ['enter', 'in', 'exit']
 
 path.clear()
 
+# Test that __exit__ is called even when an exception occurs
+class B:
+    def __init__(self):
+        self.path = []
+    
+    def __enter__(self):
+        path.append('enter')
+        return self
+    
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        path.append('exit')
+        if exc_type is not None:
+            path.append('exception')
+        return False  # propagate exception
+
+try:
+    with B():
+        path.append('before_raise')
+        raise ValueError('test')
+        path.append('after_raise')  # should not be reached
+except ValueError:
+    pass
+
+assert path == ['enter', 'before_raise', 'exit', 'exception'], f"Expected ['enter', 'before_raise', 'exit', 'exception'], got {path}"
+
 


### PR DESCRIPTION

<img width="797" height="729" alt="Screenshot 2025-12-27 012146" src="https://github.com/user-attachments/assets/2a8ef5e3-3e79-4baa-9d14-2a2ece679317" />
Problem: When an exception occurs in a WITH block, __exit__ was not called, preventing proper cleanup of context managers.

Solution:
1. Wrap WITH block body in try-except structure
2. On normal exit: call __exit__(None, None, None)
3. On exception: call __exit__ with exception info before re-raising

Changes:
- compiler.c: Wrap WITH body in try-except, ensure __exit__ called in both paths
- ceval.c: Update OP_WITH_EXIT to accept three arguments (exc_type, exc_val, exc_tb)
- tests/520_context.py: Add test to verify __exit__ called on exceptions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined context manager handling in with statements with improved exception path support, adjusting stack management and execution flow for consistent cleanup behavior across normal and error scenarios.

* **Tests**
  * Added test cases to validate proper exception handling and resource cleanup when errors are raised within with statement blocks.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->