### PR TITLE
Add s390x (big-endian) architecture support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,10 @@ else()
     endif()
 endif()
 
+if (CMAKE_C_BYTE_ORDER STREQUAL "BIG_ENDIAN")
+    add_compile_definitions(PK_BIG_ENDIAN)
+endif()
+
 include_directories(${CMAKE_CURRENT_LIST_DIR}/include)
 file(GLOB_RECURSE POCKETPY_SRC ${CMAKE_CURRENT_LIST_DIR}/src/*.c)
 

--- a/src/common/dmath.c
+++ b/src/common/dmath.c
@@ -13,7 +13,11 @@ typedef union
 {
     double   f;
     uint64_t u;
+#ifdef PK_BIG_ENDIAN
+    struct {int32_t  i1,i0;} s;
+#else
     struct {int32_t  i0,i1;} s;
+#endif
 }  udi_t;
 
 // https://github.com/akohlmey/fastermath/blob/master/src/exp.c#L63

--- a/src/modules/pickle.c
+++ b/src/modules/pickle.c
@@ -85,13 +85,16 @@ static void pkl__emit_int(PickleObject* buf, py_i64 val) {
     }
     if(INT8_MIN <= val && val <= INT8_MAX) {
         pkl__emit_op(buf, PKL_INT8);
-        PickleObject__write_bytes(buf, &val, 1);
+        int8_t v = (int8_t)val;
+        PickleObject__write_bytes(buf, &v, 1);
     } else if(INT16_MIN <= val && val <= INT16_MAX) {
         pkl__emit_op(buf, PKL_INT16);
-        PickleObject__write_bytes(buf, &val, 2);
+        int16_t v = (int16_t)val;
+        PickleObject__write_bytes(buf, &v, 2);
     } else if(INT32_MIN <= val && val <= INT32_MAX) {
         pkl__emit_op(buf, PKL_INT32);
-        PickleObject__write_bytes(buf, &val, 4);
+        int32_t v = (int32_t)val;
+        PickleObject__write_bytes(buf, &v, 4);
     } else {
         pkl__emit_op(buf, PKL_INT64);
         PickleObject__write_bytes(buf, &val, 8);

--- a/src/public/GlobalSetup.c
+++ b/src/public/GlobalSetup.c
@@ -24,11 +24,6 @@ void py_initialize() {
 
     pk_names_initialize();
 
-    // check endianness
-    int x = 1;
-    bool is_little_endian = *(char*)&x == 1;
-    if(!is_little_endian) c11__abort("is_little_endian != true");
-
     _Static_assert(sizeof(py_TValue) == 24, "sizeof(py_TValue) != 24");
     _Static_assert(offsetof(py_TValue, extra) == 4, "offsetof(py_TValue, extra) != 4");
 


### PR DESCRIPTION
This PR adds full support for s390x and other big-endian architectures.

Changes:
1. Remove restrictive little-endian requirement check
2. Do an architecture check when laying out union members as data that is in the first 32-bits in little endian will be in second 32-bits in big endian (in this context as double is 64-bits)
3. Fix pickle integer serialization for endianness portability. `pickle_dumps` eventually calls `pkl__emit_int` which used to pass down 64-bit variable to `PickleObject__write_bytes` which does a `c11_vector__extend` which does a `memcpy` of first `size` bytes from the source. While this is correct in little-endian, for big-endian machines this is an obvious error.

All changes ensure correct behavior on both little-endian and big-endian systems without breaking existing functionality.

Tested on: s390x and x86