### PR TITLE
Use current Python executable for build and test scripts 

### DIFF
--- a/cmake_build.py
+++ b/cmake_build.py
@@ -2,7 +2,7 @@ import os
 import sys
 import shutil
 
-assert os.system("python prebuild.py") == 0
+assert os.system(f'"{sys.executable}" prebuild.py') == 0
 
 if not os.path.exists("build"):
     os.mkdir("build")

--- a/scripts/run_tests.py
+++ b/scripts/run_tests.py
@@ -7,7 +7,7 @@ pkpy_exe = 'main.exe' if sys.platform == 'win32' else './main'
 
 def test_file(filepath, cpython=False):
     if cpython:
-        return os.system("python " + filepath) == 0
+        return os.system(f'"{sys.executable}" {filepath}') == 0
     code = os.system(pkpy_exe + ' ' + filepath)
     if code != 0:
         print('Return code:', code)
@@ -74,7 +74,7 @@ exit()
             print(res.stdout)
             exit(1)
 
-code = os.system(f'python compileall.py {pkpy_exe} tests tmp/tests')
+code = os.system(f'"{sys.executable}" compileall.py {pkpy_exe} tests tmp/tests')
 assert code == 0
 
 if len(sys.argv) == 2:


### PR DESCRIPTION
## Summary
- Use sys.executable instead of assuming `python` is available
- Fix build and test scripts on systems where Python is invoked as `python3`
- Verified by running the full test suite successfully

## Testing
- `python3 cmake_build.py Release`
- `python3 scripts/run_tests.py`

All tests passed.